### PR TITLE
feat(rds): add public command to generate report of publicly exposed RDS instances

### DIFF
--- a/iam/get.go
+++ b/iam/get.go
@@ -73,9 +73,9 @@ func ListUsers(showOnly string) error {
 	}
 	for _, user := range data {
 		if user.HasConsoleAccess() {
-			summaryStats["consoleAccess"] += 1
+			summaryStats["consoleAccess"]++
 		}
-		summaryStats[user.CheckStatus()] += 1
+		summaryStats[user.CheckStatus()]++
 
 		if showOnly == "" || showOnly == user.CheckStatus() {
 			t.AppendRow([]interface{}{
@@ -101,9 +101,9 @@ func ListUsers(showOnly string) error {
 			for _, key := range user.accessKeys {
 				switch aws.StringValue(key.status) {
 				case "Active":
-					summaryStats["activeKeys"] += 1
+					summaryStats["activeKeys"]++
 				case "Inactive":
-					summaryStats["inactiveKeys"] += 1
+					summaryStats["inactiveKeys"]++
 				}
 				st.AppendRow([]interface{}{
 					aws.StringValue(key.id),

--- a/main.go
+++ b/main.go
@@ -138,6 +138,17 @@ throttling from AWS with an exponential backoff with retry.
 							return nil
 						},
 					},
+					{
+						Name:  "public",
+						Usage: "Produce report of instances that have public interfaces attached",
+						Action: func(c *cli.Context) error {
+							err := rds.ListPublicInterfaces()
+							if err != nil {
+								return cli.NewExitError(err, 2)
+							}
+							return nil
+						},
+					},
 				},
 			},
 			{

--- a/main.go
+++ b/main.go
@@ -141,6 +141,23 @@ throttling from AWS with an exponential backoff with retry.
 					{
 						Name:  "public",
 						Usage: "Produce report of instances that have public interfaces attached",
+						UsageText: `
+Produces a report that displays a list RDS servers that are configured as Publicly Accessible.
+
+The report contains:
+
+DB INSTANCE:
+    - Name of the instance
+
+ENGINE:
+    - RDS DB engine
+
+SECURITY GROUPS:
+    - Security Group ID
+    - Security Group Name
+    - Inbound Port
+    - CIDR rules applied to the Port
+`,
 						Action: func(c *cli.Context) error {
 							err := rds.ListPublicInterfaces()
 							if err != nil {

--- a/rds/public.go
+++ b/rds/public.go
@@ -1,0 +1,89 @@
+package rds
+
+import (
+	"fmt"
+	"github.com/GoodwayGroup/gw-aws-audit/sg"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	as "github.com/clok/awssession"
+	"github.com/clok/kemba"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"net"
+	"os"
+)
+
+// ListPublicInterfaces will list RDS instances with a public interface attached.
+func ListPublicInterfaces() error {
+	k := kemba.New("gw-aws-audit:rds:ListPublicInterfaces")
+	sess, err := as.New()
+	if err != nil {
+		return err
+	}
+	client := rds.New(sess)
+	cnt := 0
+
+	var result *rds.DescribeDBInstancesOutput
+	result, err = client.DescribeDBInstances(&rds.DescribeDBInstancesInput{})
+
+	if err != nil {
+		fmt.Println("Failed to list instances")
+		return err
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"DB Instance", "Engine", "Security Groups"})
+
+	k.Printf("checking %d RDS instances", len(result.DBInstances))
+	for _, db := range result.DBInstances {
+		if aws.BoolValue(db.PubliclyAccessible) {
+			cnt++
+
+			var sgIDs []*string
+			for _, sec := range db.VpcSecurityGroups {
+				sgIDs = append(sgIDs, sec.VpcSecurityGroupId)
+			}
+			sgs, err := sg.GetSecurityGroups(sgIDs)
+			if err != nil {
+				return err
+			}
+			var securityGroups []*sg.SecurityGroup
+			for _, sec := range sgs {
+				securityGroups = append(securityGroups, sec)
+			}
+			k.Log(securityGroups)
+
+			var ips []string
+			var stub string
+			for _, sec := range securityGroups {
+				for token, rule := range sec.Rules() {
+					port, _, _ := sec.ParseRuleToken(token)
+					for _, ip := range rule {
+						_, ipv4Net, _ := net.ParseCIDR(aws.StringValue(ip.CidrIp))
+						ips = append(ips, ipv4Net.String())
+					}
+					stub = fmt.Sprintf("%s\t%s\t%s\n\n\t", sec.ID(), sec.Name(), port)
+					for i, ip := range ips {
+						if i != 0 && i%4 == 0 {
+							stub = fmt.Sprintf("%s\n\t", stub)
+						}
+						stub = fmt.Sprintf("%s %20s", stub, ip)
+					}
+					stub = fmt.Sprintf("%s\n", stub)
+				}
+			}
+
+			name := aws.StringValue(db.DBInstanceIdentifier)
+			engine := aws.StringValue(db.Engine)
+
+			t.AppendRow([]interface{}{name, engine, stub})
+		}
+	}
+
+	// There are a LOT of metrics to consider
+	// See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html
+	t.AppendFooter(table.Row{"DB Instances", cnt})
+	t.Render()
+	return nil
+}

--- a/sg/attached.go
+++ b/sg/attached.go
@@ -18,7 +18,7 @@ func ListAttachedSecurityGroups() error {
 		return err
 	}
 
-	var attached []*securityGroup
+	var attached []*SecurityGroup
 	for _, sg := range sgs {
 		if sg.attached != nil {
 			attached = append(attached, sg)

--- a/sg/aws.go
+++ b/sg/aws.go
@@ -23,7 +23,7 @@ func GenerateExternalAWSIPReport() error {
 		return err
 	}
 
-	var securityGroups []*securityGroup
+	var securityGroups []*SecurityGroup
 	for _, sg := range sgs {
 		securityGroups = append(securityGroups, sg)
 	}

--- a/sg/detached.go
+++ b/sg/detached.go
@@ -16,7 +16,7 @@ func ListDetachedSecurityGroups() error {
 		return err
 	}
 
-	var detached []*securityGroup
+	var detached []*SecurityGroup
 	for _, sg := range sgs {
 		if sg.attached == nil {
 			detached = append(detached, sg)

--- a/sg/helper.go
+++ b/sg/helper.go
@@ -36,7 +36,7 @@ func generateReport(c *cli.Context, checkFxn func(a []string, b string) bool, po
 		return err
 	}
 
-	var securityGroups []*securityGroup
+	var securityGroups []*SecurityGroup
 	for _, sg := range sgs {
 		if sg.attached != nil || c.Bool("all") {
 			securityGroups = append(securityGroups, sg)
@@ -95,7 +95,7 @@ func parseToken(token string) (port string, protocol string, sgIDs string) {
 	return parts[0], parts[1], parts[2]
 }
 
-func processSecurityGroups(securityGroups []*securityGroup, groupedCIDRs *groupedIPBlockRules, checkFxn func(a []string, b string) bool, ports []string, ignoredProtocols map[string]bool) (*groupedSecurityGroups, error) {
+func processSecurityGroups(securityGroups []*SecurityGroup, groupedCIDRs *groupedIPBlockRules, checkFxn func(a []string, b string) bool, ports []string, ignoredProtocols map[string]bool) (*groupedSecurityGroups, error) {
 	kl := ksg.Extend("processSecurityGroups")
 	mappedSGs := newGroupedSecurityGroups()
 
@@ -208,7 +208,7 @@ func generateIPBlockRules(c *cli.Context) (*groupedIPBlockRules, error) {
 	return groupedCIDRs, nil
 }
 
-func printTable(data map[*securityGroup][]*portToIP) {
+func printTable(data map[*SecurityGroup][]*portToIP) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.SetStyle(table.StyleLight)
@@ -222,7 +222,7 @@ func printTable(data map[*securityGroup][]*portToIP) {
 			if i == 0 {
 				id = sec.id
 				name = sec.name
-				usage = sec.getAttachmentsAsString()
+				usage = sec.GetAttachmentsAsString()
 			}
 			t.AppendRow([]interface{}{
 				id,
@@ -238,7 +238,7 @@ func printTable(data map[*securityGroup][]*portToIP) {
 	t.Render()
 }
 
-func printAmazonTable(data map[*securityGroup][]*portToIP) {
+func printAmazonTable(data map[*SecurityGroup][]*portToIP) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.SetStyle(table.StyleLight)
@@ -252,7 +252,7 @@ func printAmazonTable(data map[*securityGroup][]*portToIP) {
 			if i == 0 {
 				id = sec.id
 				name = sec.name
-				usage = sec.getAttachmentsAsString()
+				usage = sec.GetAttachmentsAsString()
 			}
 			t.AppendRow([]interface{}{
 				id,

--- a/sg/types_test.go
+++ b/sg/types_test.go
@@ -1,0 +1,83 @@
+package sg
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSecurityGroup_ID(t *testing.T) {
+	is := assert.New(t)
+
+	t.Run("should return the literal string", func(t *testing.T) {
+		test := "sg-1234"
+		sg := SecurityGroup{
+			id: test,
+		}
+
+		is.Equal(test, sg.ID())
+	})
+
+	t.Run("should return empty string when there is no value", func(t *testing.T) {
+		sg := SecurityGroup{}
+
+		is.Equal("", sg.ID())
+	})
+}
+
+func TestSecurityGroup_Name(t *testing.T) {
+	is := assert.New(t)
+
+	t.Run("should return the literal string", func(t *testing.T) {
+		test := "test-name"
+		sg := SecurityGroup{
+			name: test,
+		}
+
+		is.Equal(test, sg.Name())
+	})
+
+	t.Run("should return empty string when there is no value", func(t *testing.T) {
+		sg := SecurityGroup{}
+
+		is.Equal("", sg.Name())
+	})
+}
+
+func TestSecurityGroup_Attachments(t *testing.T) {
+	is := assert.New(t)
+
+	t.Run("should return the literal string", func(t *testing.T) {
+		attachments := map[string]int{"ec2": 1, "rds": 2}
+		sg := SecurityGroup{
+			attached: attachments,
+		}
+
+		is.Equal(attachments, sg.Attachments())
+	})
+
+	t.Run("should return empty string when there is no value", func(t *testing.T) {
+		sg := SecurityGroup{}
+
+		var test map[string]int
+		is.Equal(test, sg.Attachments())
+	})
+}
+
+func TestSecurityGroup_GetAttachmentsAsString(t *testing.T) {
+	is := assert.New(t)
+
+	t.Run("should return the literal string", func(t *testing.T) {
+		attachments := map[string]int{"ec2": 1, "rds": 2}
+		sg := SecurityGroup{
+			attached: attachments,
+		}
+
+		is.Equal("ec2: 1 rds: 2", sg.GetAttachmentsAsString())
+	})
+
+	t.Run("should return empty string when there is no value", func(t *testing.T) {
+		sg := SecurityGroup{}
+
+		is.Equal("", sg.GetAttachmentsAsString())
+	})
+}


### PR DESCRIPTION
added the `gw-aws-audit rds public` command

Produces a report that displays a list RDS servers that are configured as Publicly Accessible.
The report contains:

```
DB INSTANCE:
    - Name of the instance
ENGINE:
    - RDS DB engine
SECURITY GROUPS:
    - Security Group ID
    - Security Group Name
    - Inbound Port
    - CIDR rules applied to the Port
```

Example output
```
┌─────────────────────────┬───────────────────┬──────────────────────────────────────────────────────────────────────────────────────────┐
│ DB INSTANCE             │ ENGINE            │ SECURITY GROUPS                                                                          │
├─────────────────────────┼───────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
│ metadata-db-1234        │ postgres          │ sg-1234589313123    airflow-metadb-prod-v2-sg    5432                                    │
│                         │                   │                                                                                          │
│                         │                   │            10.176.50.0/24       10.176.51.0/24       10.176.52.0/24        10.176.0.0/16 │
│                         │                   │           10.176.1.233/32                                                                │
│                         │                   │                                                                                          │
│ ab-prod-db              │ aurora-postgresql │ sg-ac67ac8a    rds-launch-wizard-28    5432                                              │
│                         │                   │                                                                                          │
│                         │                   │             10.176.0.0/16                                                                │
│                         │                   │                                                                                          │
├─────────────────────────┼───────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
│ DB INSTANCES            │ 2                 │                                                                                          │
└─────────────────────────┴───────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘
```